### PR TITLE
allow refresh tokens to be expired in the future to allow a window of

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -174,6 +174,7 @@ module Doorkeeper
            end)
     option :skip_authorization,            default: ->(routes) {}
     option :access_token_expires_in,       default: 7200
+    option :refresh_token_revoked_in,      default: 0
     option :authorization_code_expires_in, default: 600
     option :orm,                           default: :active_record
     option :native_redirect_uri,           default: 'urn:ietf:wg:oauth:2.0:oob'

--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -15,6 +15,7 @@ module Doorkeeper
     validates :refresh_token, uniqueness: true, if: :use_refresh_token?
 
     attr_accessor :use_refresh_token
+
     if ::Rails.version.to_i < 4 || defined?(ProtectedAttributes)
       attr_accessible :application_id, :resource_owner_id, :expires_in,
                       :scopes, :use_refresh_token

--- a/lib/doorkeeper/models/revocable.rb
+++ b/lib/doorkeeper/models/revocable.rb
@@ -5,6 +5,10 @@ module Doorkeeper
         update_attribute :revoked_at, clock.now
       end
 
+      def revoke_in(time)
+        update_attribute :revoked_at, (DateTime.now + time)
+      end
+
       def revoked?
         !!(revoked_at && revoked_at <= DateTime.now)
       end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -28,7 +28,11 @@ module Doorkeeper
       private
 
       def before_successful_response
-        refresh_token.revoke
+        if server.refresh_token_revoked_in
+          refresh_token.revoke_in(server.refresh_token_revoked_in)
+        else
+          refresh_token.revoke
+        end
         create_access_token
       end
 

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -29,6 +29,9 @@ Doorkeeper.configure do
   # Issue access tokens with refresh token (disabled by default)
   use_refresh_token
 
+  # Revoke the refresh token in a set time. Defaults to now
+  # refresh_token_revoked_in 0.seconds
+
   # Define access token scopes for your provider
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes


### PR DESCRIPTION
time in case of network or other failures
