### PR TITLE
[LDA-1598][LINK-1354] Custom access token class

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -27,7 +27,7 @@ module Doorkeeper
     private
 
     def matching_token?
-      AccessToken.matching_token_for pre_auth.client,
+      Doorkeeper.configuration.access_token_model.matching_token_for pre_auth.client,
                                      current_resource_owner.id,
                                      pre_auth.scopes
     end

--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -7,7 +7,7 @@ module Doorkeeper
     end
 
     def destroy
-      AccessToken.revoke_all_for params[:id], current_resource_owner
+      Doorkeeper.configuration.access_token_model.revoke_all_for params[:id], current_resource_owner
       redirect_to oauth_authorized_applications_url, notice: I18n.t(:notice, scope: [:doorkeeper, :flash, :authorized_applications, :destroy])
     end
   end

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -66,8 +66,8 @@ module Doorkeeper
     end
 
     def token
-      @token ||= AccessToken.by_token(request.POST['token']) ||
-        AccessToken.by_refresh_token(request.POST['token'])
+      @token ||= Doorkeeper.configuration.access_token_model.by_token(request.POST['token']) ||
+      Doorkeeper.configuration.access_token_model.by_refresh_token(request.POST['token'])
     end
 
     def strategy

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -248,6 +248,9 @@ doorkeeper.
     option :base_controller,
            default: 'ActionController::Base'
 
+    option :access_token_class,
+           default: 'AccessToken'
+
     attr_reader :reuse_access_token
 
     def refresh_token_enabled?
@@ -291,6 +294,10 @@ doorkeeper.
 
     def token_grant_types
       @token_grant_types ||= calculate_token_grant_types
+    end
+
+    def access_token_model
+      @access_token_model ||= Doorkeeper.configuration.access_token_class.constantize
     end
 
     private

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -37,11 +37,11 @@ module Doorkeeper
       #
       def old_refresh_token
         @old_refresh_token ||=
-          AccessToken.by_refresh_token(previous_refresh_token)
+          Doorkeeper.configuration.access_token_model.by_refresh_token(previous_refresh_token)
       end
 
       def refresh_token_revoked_on_use?
-        AccessToken.refresh_token_revoked_on_use?
+        Doorkeeper.configuration.access_token_model.refresh_token_revoked_on_use?
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -18,7 +18,7 @@ module Doorkeeper
         end
 
         def issue_token
-          @token ||= AccessToken.find_or_create_for(
+          @token ||= Doorkeeper.configuration.access_token_model.find_or_create_for(
             pre_auth.client,
             resource_owner.id,
             pre_auth.scopes,

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -32,7 +32,7 @@ module Doorkeeper
       end
 
       def find_or_create_access_token(client, resource_owner_id, scopes, server)
-        @access_token = AccessToken.find_or_create_for(
+        @access_token = Doorkeeper.configuration.access_token_model.find_or_create_for(
           client,
           resource_owner_id,
           scopes,

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -3,7 +3,7 @@ module Doorkeeper
     class ClientCredentialsRequest < BaseRequest
       class Creator
         def call(client, scopes, attributes = {})
-          AccessToken.find_or_create_for(
+          Doorkeeper.configuration.access_token_model.find_or_create_for(
             client, nil, scopes, attributes[:expires_in],
             attributes[:use_refresh_token])
         end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -38,7 +38,7 @@ module Doorkeeper
       end
 
       def refresh_token_revoked_on_use?
-        Doorkeeper::AccessToken.refresh_token_revoked_on_use?
+        Doorkeeper.configuration.access_token_model.refresh_token_revoked_on_use?
       end
 
       def default_scopes
@@ -46,7 +46,7 @@ module Doorkeeper
       end
 
       def create_access_token
-        @access_token = AccessToken.create!(access_token_attributes)
+        @access_token = Doorkeeper.configuration.access_token_model.create!(access_token_attributes)
       end
 
       def access_token_attributes

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -12,7 +12,7 @@ module Doorkeeper
 
         def authenticate(request, *methods)
           if token = from_request(request, *methods)
-            access_token = AccessToken.by_token(token)
+            access_token = Doorkeeper.configuration.access_token_model.by_token(token)
             access_token.revoke_previous_refresh_token! if access_token
             access_token
           end

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -17,7 +17,7 @@ module Doorkeeper
     #   Applications authorized for the Resource Owner
     #
     def self.authorized_for(resource_owner)
-      resource_access_tokens = AccessToken.active_for(resource_owner)
+      resource_access_tokens = Doorkeeper.configuration.access_token_model.active_for(resource_owner)
       where(id: resource_access_tokens.select(:application_id).distinct)
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       delegate :credentials, :parameters, to: :server
 
       def refresh_token
-        AccessToken.by_refresh_token(parameters[:refresh_token])
+        Doorkeeper.configuration.access_token_model.by_refresh_token(parameters[:refresh_token])
       end
 
       def request

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -331,4 +331,21 @@ describe Doorkeeper, 'configuration' do
       it { expect(Doorkeeper.configuration.base_controller).to eq('ApplicationController') }
     end
   end
+
+  describe 'access_token_class' do
+    it 'uses default doorkeeper value' do
+      expect(subject.access_token_class).to eq("Doorkeeper::AccessToken")
+      expect(subject.access_token_model).to be(Doorkeeper::AccessToken)
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_token_class 'FakeCustomModel'
+      end
+
+      expect(subject.access_token_class).to eq('FakeCustomModel')
+      expect(subject.access_token_model).to be(FakeCustomModel)
+    end
+  end
 end


### PR DESCRIPTION
Introduce a way to use custom class for AccessToken

Keeping the same API as current open source fork so that there is no breaking change when we migrate back to OS version
https://github.com/doorkeeper-gem/doorkeeper/commit/4171d0b17c1bb35020d0df2a74c517987928ae8a#diff-d4ed41e5cd854dad8edf2e617b038a62d12547817c447a6864ed0addd33a622dR354